### PR TITLE
Feature/get page data

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,10 @@
 
 This project will retrieve program hashtags from the radiko website.
 
-## Getting Started
+- 北海道〜沖縄までのラジオ局名を取得
+- 1日のラジオ番組全てのハッシュタグを取得(全てのラジオ局で行う)
 
-This project is a starting point for a Flutter application.
+以下のデモ動画では、取得時間の問題から北海道・東北に対してのみリクエストを投げている(３０秒近くはローディングなので改善必須)
 
-A few resources to get you started if this is your first Flutter project:
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
-
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+https://user-images.githubusercontent.com/89247188/168004700-571fb1e4-4d92-4059-93d1-39881d53152d.mp4

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:get_radiko_hash_tags/scraping/scraping.dart';
 
 void main() {
   runApp(const MyApp());
@@ -15,7 +16,7 @@ class MyApp extends StatelessWidget {
 
         primarySwatch: Colors.blue,
       ),
-      home: const MyHomePage(title: 'Flutter Demo Home Page'),
+      home: const ScrapingPage(),
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,55 +16,7 @@ class MyApp extends StatelessWidget {
 
         primarySwatch: Colors.blue,
       ),
-      home: const ScrapingPage(),
-    );
-  }
-}
-
-class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key? key, required this.title}) : super(key: key);
-
-  final String title;
-
-  @override
-  State<MyHomePage> createState() => _MyHomePageState();
-}
-
-class _MyHomePageState extends State<MyHomePage> {
-  int _counter = 0;
-
-  void _incrementCounter() {
-    setState(() {
-      _counter++;
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: Text(widget.title),
-      ),
-      body: Center(
-        child: Column(
-
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headline4,
-            ),
-          ],
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ),
+      home: ScrapingPage(),
     );
   }
 }

--- a/lib/scraping/get_hash_tags.dart
+++ b/lib/scraping/get_hash_tags.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+
+import 'package:html/parser.dart';
+import 'package:http/http.dart' as http;
+
+Future<List<String>> getHashTags(String programUrl) async {
+  final String url = 'https://radiko.jp$programUrl';
+  final target = Uri.parse(url);
+  final response = await http.get(target);
+  final String responseBody = utf8.decode(response.bodyBytes);
+  if (response.statusCode != 200) {
+    Exception(response.statusCode.toString());
+  }
+  final document = parse(responseBody);
+  final String result = document
+          .querySelector(
+              '#content > div.content.content__main > div > div.content__rwd.rwd.channel-detail > div > div > div.program-table__body.program-table__body--col7 > div.program-table__outer > div.program-table__items > div:nth-child(1)')
+          ?.innerHtml ??
+      '情報なし';
+
+  final regHashTags1 = RegExp(r'(?<=「#).+?(?=」</a>)'); // HBC
+  // final regHashTags2 = RegExp(r'#.+?(?=<br>T)');
+  // final regHashTags3 = RegExp(r'(?<=twitterハッシュタグは「).+?(?=」<br>t)');
+
+
+  final List<String> hashTags1 =
+      regHashTags1.allMatches(result).map((e) => e.group(0).toString()).toSet().toList();
+
+  // final List<String> hashTags2 =
+  // regHashTags2.allMatches(result).map((e) => e.group(0).toString()).toSet().toList();
+  //
+  // final List<String> hashTags3 =
+  // regHashTags3.allMatches(result).map((e) => e.group(0).toString()).toSet().toList();
+
+  print('return hashTagList');
+  return hashTags1;
+  // return hashTags1 + hashTags2 + hashTags3;
+}

--- a/lib/scraping/scraping.dart
+++ b/lib/scraping/scraping.dart
@@ -1,0 +1,98 @@
+import 'dart:convert';
+import 'dart:developer';
+
+import 'package:flutter/material.dart';
+import 'package:get_radiko_hash_tags/scraping/scraping_detail.dart';
+import 'package:html/parser.dart';
+import 'package:http/http.dart' as http;
+
+typedef HashTags = Map<String, List<List<String>>>;
+
+class ScrapingPage extends StatefulWidget {
+  const ScrapingPage({Key? key}) : super(key: key);
+
+  @override
+  State<ScrapingPage> createState() => _ScrapingPageState();
+}
+
+class _ScrapingPageState extends State<ScrapingPage> {
+  HashTags programList = {};
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('radiko page'),
+      ),
+      body: ListView.builder(
+        itemBuilder: (context, index) {
+          String key = programList.keys.elementAt(index);
+          return ListTile(
+            title: Text(key),
+            onTap: () {
+              Navigator.of(context).push(MaterialPageRoute(builder: (context) {
+                return ScrapingDetail(local: key, programList: programList[key]!);
+              }));
+            }
+          );
+        },
+        itemCount: programList.length,
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final newpProgramList = await scraping();
+          setState(() {
+            programList = newpProgramList;
+          });
+        },
+        child: const Icon(Icons.search),
+      ),
+    );
+  }
+}
+
+Future<HashTags> scraping() async {
+  const String url = 'https://radiko.jp/index/';
+  final target = Uri.parse(url);
+  final response = await http.get(target);
+  final String responseBody = utf8.decode(response.bodyBytes);
+  if (response.statusCode != 200) {
+    Exception(response.statusCode.toString());
+  }
+  final document = parse(responseBody);
+  HashTags hashTagsList = normalization(document);
+  return hashTagsList;
+}
+
+HashTags normalization(document) {
+  final HashTags hashTags = {};
+  for (int i = 1; i <= 15; i += 2) {
+    final String result = document
+            .querySelector(
+                '#content > div.content.content__main > div > div > div:nth-child($i)')
+            ?.innerHtml ??
+        '情報なし';
+    final regLocal = RegExp(r'(?<=>).+?(?=<)'); // 地名
+    final regURL = RegExp(r'(?<=href=").+?(?=">)'); // URL
+    final regProgram = RegExp(r'(?<=">).+?(?=</a)'); // 番組名
+
+    final String localTitle =
+        (regLocal.firstMatch(result)?.group(0)).toString();
+
+    final List<String> url =
+        regURL.allMatches(result).map((e) => e.group(0).toString()).toList();
+
+    final List<String> programTitle = regProgram
+        .allMatches(result)
+        .map((e) => e.group(0).toString())
+        .toList();
+
+    hashTags[localTitle] = [];
+    for (int j = 0; j < url.length; j++) {
+      hashTags[localTitle]?.addAll([
+        [url[j], programTitle[j]]
+      ]);
+    }
+  }
+  return hashTags;
+}

--- a/lib/scraping/scraping_detail.dart
+++ b/lib/scraping/scraping_detail.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class ScrapingDetail extends StatelessWidget {
+  const ScrapingDetail(
+      {Key? key, required this.local, required this.programList})
+      : super(key: key);
+
+  final String local;
+  final List<List<String>> programList;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(local),
+      ),
+      body: ListView.builder(
+        itemBuilder: (context, index) {
+          return ListTile(
+            title: Text(programList[index].toString()),
+          );
+        },
+        itemCount: programList.length,
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -43,6 +43,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.16.0"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -74,6 +81,27 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  html:
+    dependency: "direct main"
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.13.4"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
   lints:
     dependency: transitive
     description:
@@ -156,6 +184,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.4.9"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,8 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  http: ^0.13.4
+  html: ^0.15.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
# radikoのWebサイトをスクレイピング(https://radiko.jp/index/)

1. ラジオ局名、radiko内のラジオ局ページURLを取得
2. 1で取得したした各ラジオ局で明示されているハッシュタグをリストで取得
3. 表示

## ハッシュタグ記載のされ方が各ページで異なるため、パターンマッチを複数作成する必要がある。
現在は、1つしか使用していないので、取得できないないページが多い